### PR TITLE
Avoid a ~risky `eval` to parse config EDN. Also, README 😇

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# screencap
+
+## Requirements
+Planck and `fdupes`, supported by [brew](http://brew.sh)
+```
+$ brew install planck fdupes
+```

--- a/main.cljs
+++ b/main.cljs
@@ -3,13 +3,11 @@
 (ns screencap
   (:require [planck.core :refer [slurp]]
             [planck.shell :refer [sh] :refer-macros [with-sh-dir]]
+            [cljs.reader]
             [goog.string.format]
             [cljs.js]))
 
-(def st (cljs.js/empty-state planck.core/init-empty-state))
-(defn- eval [str] ((cljs.js/eval-str st str nil {:eval cljs.js/js-eval :context :expr} identity) :value))
-
-(def config (eval (slurp "./config.edn")))
+(def config (cljs.reader/read-string (slurp "./config.edn")))
 
 (defn format
   "Formats a string using goog.string.format."


### PR DESCRIPTION
Couple of changes to main.cljs:
1. use `read-string` to parse EDN instead of `eval`ing
2. use `screencap.core` as namespace, avoiding warning about single-segment ns.
3. README that advises people to install `fdupes` (I didn't have that and was seeing a `launch path not accessible` error).

Thanks, learned a lot!
